### PR TITLE
Fix NPE on SpanBuilderWrapper

### DIFF
--- a/opentracing-jfr-tracer/src/main/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapper.java
+++ b/opentracing-jfr-tracer/src/main/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapper.java
@@ -42,6 +42,9 @@ final class SpanBuilderWrapper implements SpanBuilder {
 	@Override
 	public SpanBuilder asChildOf(SpanContext parent) {
 		delegate.asChildOf(parent);
+		if (parent == null) {
+			return this;
+		}
 		parentId = parent.toSpanId();
 		return this;
 	}
@@ -49,6 +52,9 @@ final class SpanBuilderWrapper implements SpanBuilder {
 	@Override
 	public SpanBuilder asChildOf(Span parent) {
 		delegate.asChildOf(parent);
+		if (parent == null) {
+			return this;
+		}
 		parentId = parent.context().toSpanId();
 		return this;
 	}
@@ -117,5 +123,12 @@ final class SpanBuilderWrapper implements SpanBuilder {
 	private String getParentSpanId() {
 		Span activeSpan = owner.scopeManager().activeSpan();
 		return parentId != null ? parentId : activeSpan != null ? activeSpan.context().toSpanId() : null;
+	}
+
+	/**
+	 * hook for unit test
+	 */
+	String parentId() {
+		return parentId;
 	}
 }

--- a/opentracing-jfr-tracer/src/main/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapper.java
+++ b/opentracing-jfr-tracer/src/main/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapper.java
@@ -62,6 +62,10 @@ final class SpanBuilderWrapper implements SpanBuilder {
 	@Override
 	public SpanBuilder addReference(String referenceType, SpanContext referencedContext) {
 		delegate.addReference(referenceType, referencedContext);
+		if (referencedContext == null) {
+			return this;
+		}
+		parentId = referencedContext.toSpanId();
 		return this;
 	}
 

--- a/opentracing-jfr-tracer/src/test/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapperTest.java
+++ b/opentracing-jfr-tracer/src/test/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapperTest.java
@@ -1,0 +1,71 @@
+package io.opentracing.contrib.jfrtracer.impl.wrapper;
+
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer.SpanBuilder;
+import io.opentracing.mock.MockTracer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class SpanBuilderWrapperTest {
+
+    @Test
+    void asChildOfOnParentSpanContext() {
+        MockTracer delegateTracer = new MockTracer();
+        Span parentSpan = delegateTracer.buildSpan("parentSpan").start();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "asChildOfOnParentSpanContext";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.asChildOf(parentSpan.context());
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNotNull(spanBuilderWrapper.parentId());
+        assertEquals(parentSpan.context().toSpanId(), spanBuilderWrapper.parentId());
+    }
+
+    @Test
+    void asChildOfOnParentSpanContextNull() {
+        MockTracer delegateTracer = new MockTracer();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "asChildOfOnParentSpanContextNull";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.asChildOf((SpanContext) null);
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNull(spanBuilderWrapper.parentId());
+    }
+
+    @Test
+    void asChildOfOnParentSpan() {
+        MockTracer delegateTracer = new MockTracer();
+        Span parentSpan = delegateTracer.buildSpan("parentSpan").start();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "asChildOfOnParentSpan";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.asChildOf(parentSpan);
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNotNull(spanBuilderWrapper.parentId());
+        assertEquals(parentSpan.context().toSpanId(), spanBuilderWrapper.parentId());
+    }
+
+    @Test
+    void asChildOfOnParentSpanNull() {
+        MockTracer delegateTracer = new MockTracer();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "asChildOfOnParentSpanNull";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.asChildOf((Span) null);
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNull(spanBuilderWrapper.parentId());
+    }
+}

--- a/opentracing-jfr-tracer/src/test/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapperTest.java
+++ b/opentracing-jfr-tracer/src/test/java/io/opentracing/contrib/jfrtracer/impl/wrapper/SpanBuilderWrapperTest.java
@@ -1,5 +1,6 @@
 package io.opentracing.contrib.jfrtracer.impl.wrapper;
 
+import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer.SpanBuilder;
@@ -65,6 +66,34 @@ class SpanBuilderWrapperTest {
                 delegateTracer.buildSpan(operationName));
 
         SpanBuilder spanBuilder = spanBuilderWrapper.asChildOf((Span) null);
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNull(spanBuilderWrapper.parentId());
+    }
+
+    @Test
+    void addReferenceOnParentSpanContext() {
+        MockTracer delegateTracer = new MockTracer();
+        Span parentSpan = delegateTracer.buildSpan("parentSpan").start();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "addReferenceOnParentSpanContext";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.addReference(References.CHILD_OF, parentSpan.context());
+        assertSame(spanBuilderWrapper, spanBuilder);
+        assertNotNull(spanBuilderWrapper.parentId());
+        assertEquals(parentSpan.context().toSpanId(), spanBuilderWrapper.parentId());
+    }
+
+    @Test
+    void addReferenceOnParentSpanContextNull() {
+        MockTracer delegateTracer = new MockTracer();
+        TracerWrapper tracerWrapper = new TracerWrapper(delegateTracer);
+        String operationName = "addReferenceOnParentSpanContextNull";
+        SpanBuilderWrapper spanBuilderWrapper = new SpanBuilderWrapper(tracerWrapper, operationName,
+                delegateTracer.buildSpan(operationName));
+
+        SpanBuilder spanBuilder = spanBuilderWrapper.addReference(References.CHILD_OF, null);
         assertSame(spanBuilderWrapper, spanBuilder);
         assertNull(spanBuilderWrapper.parentId());
     }


### PR DESCRIPTION
Fix NPE on asChildOf methods: as per javadoc the parent context|span can be null and it results to noop.
NPE detected here:
https://github.com/opentracing-contrib/java-web-servlet-filter/blob/f12d7b53a9d1bfd4d2bdeff44ded371c8e8a9f21/opentracing-web-servlet-filter/src/main/java/io/opentracing/contrib/web/servlet/filter/TracingFilter.java#L177 